### PR TITLE
[Scripts] Create icu and jsc dirs on first run, and bail out if scripts fail

### DIFF
--- a/fetch_sources.sh
+++ b/fetch_sources.sh
@@ -2,17 +2,21 @@
 
 # Copyright 2004-present Facebook. All Rights Reserved.
 
+set -e
+
 cd "$(dirname "$0")"
 
 echo "Downloading ICU"
 curl -o icu4c.tar.gz https://android.googlesource.com/platform/external/icu/+archive/master/icu4c/source.tar.gz
 
 echo "Extracting ICU"
+mkdir -p icu
 tar -zxf icu4c.tar.gz -C icu
 
 echo "Downloading JSC"
 curl -O http://builds.nightly.webkit.org/files/trunk/src/WebKit-r174650.tar.bz2
 
 echo "Extracting JSC"
+mkdir -p jsc
 tar -jxf WebKit-r174650.tar.bz2 -C jsc --strip 2 WebKit-r174650/Source/JavaScriptCore WebKit-r174650/Source/WTF
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 # Copyright 2004-present Facebook. All Rights Reserved.
 
+set -e
+
 cd "$(dirname "$0")"
 
 AAR_PATH=buck-out/gen/android-jsc.aar


### PR DESCRIPTION
Adds two small enhancements to the setup scripts:

 - Make the icu and jsc directories on the first run. Otherwise the tar command (on OS X at least) fails if the directories don't yet exist.
 - Add `set -e` to the scripts so that they bail out if any command fails

Test Plan: Run fetch_sources.sh in a clean repo and see it succeed. Run install.sh (which currently fails on the `buck build` step) and see it bails out on failure instead of going on to run the maven step.