### PR TITLE
Add minSdkVersion to AndroidManifest.xml

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,5 +4,6 @@
     package="org.webkit.android_jsc"
     android:versionCode="1"
     android:versionName="1.0">
+    <uses-sdk android:minSdkVersion="4" />
   <application />
 </manifest>


### PR DESCRIPTION
Not setting a minSdkVersion causes the Android build system to automatically add the READ_PHONE_STATE permission. (Default value of minSdkVersion and targetSdkVersion is 3)

From and Mainfest.permission docs:

> Note: If both your minSdkVersion and targetSdkVersion values are set to 3 or lower, the system implicitly grants your app this permission. If you don't need this permission, be sure your targetSdkVersion is 4 or higher.

http://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_STATE

Unfortunately I haven't been able to test this, as building android-jsc gives me a ton of errors, I guess the buildscript has to be adjusted a bit.

We initially saw this permission popping up on our app after adding the react-native dependency.
