### PR TITLE
Make build reproducible

### DIFF
--- a/fetch_sources.sh
+++ b/fetch_sources.sh
@@ -7,7 +7,7 @@ set -e
 cd "$(dirname "$0")"
 
 echo "Downloading ICU"
-curl -o icu4c.tar.gz https://android.googlesource.com/platform/external/icu/+archive/master/icu4c/source.tar.gz
+curl -o icu4c.tar.gz https://android.googlesource.com/platform/external/icu/+archive/e25a54101b72d27b345934e1574aa314c1899969/icu4c/source.tar.gz
 
 echo "Extracting ICU"
 tar -zxf icu4c.tar.gz -C icu


### PR DESCRIPTION
Because the fetch_sources.sh script currently fetched ICU master we fail to build (as icu has diverged slightly). This pins the correct version.

Closes #14.